### PR TITLE
chore: Update Get-StorAcctInfo.ps1 script for Azure Files Storage dat…

### DIFF
--- a/patterns/avd/scripts/Get-StorAcctInfo.ps1
+++ b/patterns/avd/scripts/Get-StorAcctInfo.ps1
@@ -1,11 +1,11 @@
-# Deployed from resources.bicep 
+# Deployed from resources.bicep
 # Code for Runbook associated with Action Account deployment
 # Collects Azure Files Storage data and writes output in following format:
 # AzFiles, Subscription ,RG ,StorAcct ,Share ,Quota ,GB Used ,%Available
 
 <#
 //Kusto Query for Log Analtyics
-AzureDiagnostics 
+AzureDiagnostics
 | where Category has "JobStreams"
 | where StreamType_s has "Output"
 | extend Results=split(ResultDescription,',')
@@ -27,11 +27,11 @@ $SubName = (Get-azSubscription -SubscriptionId ($StorageAccountResourceIDs -spli
 
 # Foreach storage account
 Foreach ($storageAcct in $storageAccountResourceIDs) {
-    
+
     $resourceGroup = ($storageAcct -split '/')[4]
     $storageAcctName = ($storageAcct -split '/')[8]
     #Write-Host "Working on Storage:" $storageAcctName "in" $resourceGroup
- 
+
     # $shares = Get-AzStorageShare -ResourceGroupName $resourceGroup -StorageAccountName $storageAcctName -Name 'profiles' -GetShareUsage
 	$shares = Get-AzRmStorageShare -ResourceGroupName $ResourceGroup -StorageAccountName $storageAcctName
 
@@ -42,13 +42,13 @@ Foreach ($storageAcct in $storageAccountResourceIDs) {
         #Write-Host "Share: " $shareName
         $shareQuota = $share.QuotaGiB #GB
         $shareUsageInGB = $share.ShareUsageBytes / 1073741824 # Bytes to GB
-        
-        $RemainingPercent = 100 - ($shareUsageInGB / $shareQuota)
+
+        $RemainingPercent = 100 - ($shareUsageInGB / $shareQuota * 100)
         #Write-Host "..." $shareUsageInGB "of" $shareQuota "GB used"
         #Write-Host "..." $RemainingPercent "% Available"
         # Add file share resource Id
         $shareResourceId = $share.Id
-        # Compile results 
+        # Compile results
         # AzFiles / Subscription / RG / StorAcct / Share / Quota / GB Used / %Available
         $Data = @('AzFiles', $SubName, $resourceGroup, $storageAcctName, $shareName, $shareQuota.ToString(), $shareUsageInGB.ToString(), $RemainingPercent.ToString(), $shareResourceId)
         $i = 0


### PR DESCRIPTION
…a collection Incorrect math for storage available percent

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixes the storage calculation script in the runbook which was yielding a much higher remaining value than truly existed. Values were in the 99.xx% range vs actual for remaining meaning the alert may never trigger when remaining storage is truly low.

## This PR fixes/adds/changes/removes

1. Script: Get-StorAcctInfo.ps1 line 46
Was --- $RemainingPercent = 100 - ($shareUsageInGB / $shareQuota)
New --- $RemainingPercent = 100 - ($shareUsageInGB / $shareQuota * 100)

### Breaking Changes

1. N/A

## As part of this Pull Request I have

- [X] Read the Contribution Guide and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [X] Ensured PR tests are passing
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
