### PR TITLE
JCore-AVD-Pattern-Issue221

### DIFF
--- a/docs/content/patterns/specialized/avd/Known-Issues.md
+++ b/docs/content/patterns/specialized/avd/Known-Issues.md
@@ -4,5 +4,6 @@ geekdocCollapseSection: true
 weight: 100
 ---
 
-## None at this time
+## Remaining Storage Calculation always 99.xx% / INCORRECT
+Prior to 6/29/2024
 

--- a/docs/content/patterns/specialized/avd/Whats-New.md
+++ b/docs/content/patterns/specialized/avd/Whats-New.md
@@ -14,7 +14,13 @@ Initial relocation from the Azure AVD Accelerator Brownfield with AVD specific A
 - Session Host monitoring both on performance, AVD agent health, storage, and fslogix profiles
 
 ### Bug fixes
-No new bug fixes at this time.
+#### ISSUE #221  
+(Fixed on 6/28/2024)  
 
+Storage calculation script in the runbook which was yielding a much higher remaining value than truly existed. Values were in the 99.xx% range vs actual for remaining meaning the alert may never trigger when remaining storage is truly low.  
 
+Runbook: AvdStorageLogData  
+Script: Get-StorAcctInfo.ps1 line 46  
 
+Was --- $RemainingPercent = 100 - ($shareUsageInGB / $shareQuota)  
+New --- $RemainingPercent = 100 - ($shareUsageInGB / $shareQuota * 100)  

--- a/docs/content/patterns/specialized/avd/Whats-New.md
+++ b/docs/content/patterns/specialized/avd/Whats-New.md
@@ -6,7 +6,7 @@ weight: 10
 
 For information on what's new please refer to the [Releases](https://github.com/Azure/azure-monitor-baseline-alerts/releases) page.
 
-To update your current deployment with the content from the latest release, please refer to the [Update to new release](../Update-to-new-Release) page.
+To update your current deployment with the content from the latest release, please refer to the [Update to new release](Update-to-new-Release.md) page.
 
 ## 2024-01-25
 ### New features


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixes the storage calculation script in the runbook which was yielding a much higher remaining value than truly existed. Values were in the 99.xx% range vs actual for remaining meaning the alert may never trigger when remaining storage is truly low.

## This PR fixes/adds/changes/removes
resolves #221 

1. Script: Get-StorAcctInfo.ps1 line 46
Was --- $RemainingPercent = 100 - ($shareUsageInGB / $shareQuota)
New --- $RemainingPercent = 100 - ($shareUsageInGB / $shareQuota * 100)

### Breaking Changes

1. N/A

## As part of this Pull Request I have

- [X] Read the Contribution Guide and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [X] Ensured PR tests are passing
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
